### PR TITLE
Wait for enabling to open supervise/ok

### DIFF
--- a/lib/chef/provider/service/daemontools.rb
+++ b/lib/chef/provider/service/daemontools.rb
@@ -91,7 +91,7 @@ class Chef
             if status.exitstatus == 0
 
               retry_count = 4
-              while status.stdout =~ /: supervise not running/
+              while status.stdout =~ /: supervise not running/ or status.stdout =~ /: unable to open supervise\/ok/
                 sleep 1
                 retry_count -= 1
                 status = shell_out!("#{@svstat_command} #{service_link}")


### PR DESCRIPTION
superviseによる監視が始まった直後はsuperviseディレクトリがないため、
svstatが"unable to open supervise/ok"を返すことがあります。
それを一旦無視するようにしました。
ご確認お願いします！
