### PR TITLE
Chef::Mixin::Command is removed in Chef13

### DIFF
--- a/lib/chef/provider/service/daemontools.rb
+++ b/lib/chef/provider/service/daemontools.rb
@@ -3,7 +3,6 @@ require "chef/provider/service/daemontools/version"
 require 'chef/mixin/shell_out'
 require 'chef/provider/service'
 require 'chef/resource/service'
-require 'chef/mixin/command'
 
 class Chef
   class Resource


### PR DESCRIPTION
`Chef::Mixin::Command` looks not used in the gem and is removed in Chef 13.