### PR TITLE
Move chef dependency to development, to avoid unintended chef gem update

### DIFF
--- a/chef-provider-service-daemontools.gemspec
+++ b/chef-provider-service-daemontools.gemspec
@@ -18,9 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "chef"
-
   spec.add_development_dependency "bundler", "~> 1.6"
+  spec.add_development_dependency "chef"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
 end


### PR DESCRIPTION
When `chef` dependency is written as `add_dependency`, every chef-client run causes chef gem installation, which updates chef gem update.
In packaged (RPM, deb) chef release, chef gem is bundled in the package and the version is not intended to updated not by package update, so the `chef` dependency should only be written in `add_development_dependency`.